### PR TITLE
ズームレベル15のdem5aも併用するように改造

### DIFF
--- a/JapanGSITerrainProvider.js
+++ b/JapanGSITerrainProvider.js
@@ -17,12 +17,12 @@ var
 
     var trailingSlashRegex = /\/$/;
     var defaultCredit = new Credit('国土地理院');
-    var GSI_MAX_TERRAIN_LEVEL = 14;
+    var GSI_MAX_TERRAIN_LEVEL = 15;
 
     var JapanGSITerrainProvider = function JapanGSITerrainProvider(options) {
         options = defaultValue(options, {});
 
-        var url = defaultValue(options.url, '//cyberjapandata.gsi.go.jp/xyz/dem/');
+        var url = defaultValue(options.url, '//cyberjapandata.gsi.go.jp/xyz/dem');
 
         if (!trailingSlashRegex.test(url)) {
             url = url + '/';
@@ -70,7 +70,8 @@ var
         var shiftx = (orgx % Math.pow(2, shift + 1)) / Math.pow(2, shift + 1);
         var shifty = (orgy % Math.pow(2, shift)) / Math.pow(2, shift);
 
-        var url = this._url + level + '/' + x + '/' + y + '.txt';
+        var url = this._url + (level == 15 ? '5a' : '') +
+          '/' + level + '/' + x + '/' + y + '.txt';
 
         var proxy = this._proxy;
         if (defined(proxy)) {
@@ -163,4 +164,3 @@ var
 
     Cesium.JapanGSITerrainProvider = JapanGSITerrainProvider;
 })();
-

--- a/JapanGSITerrainProvider.js
+++ b/JapanGSITerrainProvider.js
@@ -24,9 +24,11 @@ var
 
         var url = defaultValue(options.url, '//cyberjapandata.gsi.go.jp/xyz/dem');
 
+/*
         if (!trailingSlashRegex.test(url)) {
             url = url + '/';
         }
+*/
 
         this._url = url;
         this._proxy = options.proxy;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Cesium-JapanGSI
 ===============
 
+このフォークの特徴
+---------------
+https://github.com/gsi-cyberjapan/elevation-php/blob/master/getelevation.php に示されている「dem5a」も活用して、特に都市域で詳しく地形が見えるようにしています。
+
 概要(Abstruct)
 --------------
 
@@ -12,7 +16,7 @@ Libraries which make Japan GSI's APIs can be used with Cesium.
 国土地理院の提供する地図画像タイル群から、好きなレイヤを組み合わせてCesiumの地図タイルレイヤを生成するライブラリです。  
 Cesium's image tile provider from Japan GSI's map image tile service.
 
-#### プロパティ / Property 
+#### プロパティ / Property
 
 * layerLists
 
@@ -70,7 +74,3 @@ You should use these libraries with Cesium.Viewer's baseLayerPicker property as 
 * [Cesium:WebGL Virtual Globe and Map Engine](http://cesiumjs.org/index.html)
 * [国土地理院地図タイル / Japan GSI tile API](http://portal.cyberjapan.jp/help/development/ichiran.html)
 * [サンプル / Example](http://t.tilemap.jp.s3.amazonaws.com/cesium/index.html)
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 Cesium-JapanGSI
 ===============
 
-このフォークの特徴
----------------
-https://github.com/gsi-cyberjapan/elevation-php/blob/master/getelevation.php に示されている「dem5a」も活用して、特に都市域で詳しく地形が見えるようにしています。
-
 概要(Abstruct)
 --------------
 
 国土地理院の地図系APIをCesiumで利用可能にするライブラリ群です。  
-Libraries which make Japan GSI's APIs can be used with Cesium. 
+Libraries which make Japan GSI's APIs can be used with Cesium.
 
 ### JapanGSIImageryProvider
 
@@ -68,6 +64,8 @@ If you want to emphasize height of terrain, you can give powering value by this 
 前者は、falseにしないと、Cesium標準の地図セット切り替えコントロールが出てきてしまい、設定した地図タイル、地形が反映されません。  
 後者は、trueにしないと、地形の地面の下に描画した地物も、透けて見えてしまいます。  
 You should use these libraries with Cesium.Viewer's baseLayerPicker property as false and viewer.scene.globe.depthTestAgainstTerrain property as true.
+
+https://github.com/gsi-cyberjapan/elevation-php/blob/master/getelevation.php に示されている「dem5a」も活用して、特に都市域で詳しく地形が見えるようにしています。
 
 ### 参照 / See other
 


### PR DESCRIPTION
特に都市域で詳しく地形が見えることを目指して、https://github.com/gsi-cyberjapan/elevation-php/blob/master/getelevation.php に示されている dem5a も活用するようにしてみました。

dem5a の整備領域は全国ではなく、http://maps.gsi.go.jp/?ll=38.68551%2C138.076172&z=4&base=std&ls=fgd2&disp=1&vs=c1j0l0u0#4/38.685510/138.076172 で示されています。

地理院タイル一覧には掲載されていないデータを使うこと、全国をカバーしているわけではないデータを使うことから、設計ポリシー上の検討が必要かもしれません。また、実装についても「/」の扱いなど、ちょっと汎用性を崩す改造になっていますが、あわせて吟味いただければと思います。