### PR TITLE
CESIUM >1.35 obsolutes throttleRequestByServer

### DIFF
--- a/JapanGSITerrainProvider.js
+++ b/JapanGSITerrainProvider.js
@@ -83,10 +83,14 @@ var
         var promise;
 
         throttleRequests = defaultValue(throttleRequests, true);
-        if (throttleRequests) {
-            promise = throttleRequestByServer(url, loadText);
-            if (!defined(promise)) {
-                return undefined;
+        if ( throttleRequestByServer ){ // Patch for > CESIUM1.35
+            if (throttleRequests) {
+                promise = throttleRequestByServer(url, loadText);
+                if (!defined(promise)) {
+                    return undefined;
+                }
+            } else {
+                promise = loadText(url);
             }
         } else {
             promise = loadText(url);


### PR DESCRIPTION
最近のCESIUMではthrottleRequestByServer相当の機能がloadTextその他のコールで自動的に動作するようになり、関数が廃止されたようです。
> https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CHANGES.md
